### PR TITLE
Use current directory.

### DIFF
--- a/src/msbuild/ILRepack.cs
+++ b/src/msbuild/ILRepack.cs
@@ -371,9 +371,9 @@ namespace ILRepack.MSBuild.Task
         /// <returns></returns>
         private string BuildPath(string path)
         {
-            var solutionDir = Path.GetDirectoryName(BuildEngine.ProjectFileOfTaskNode);
-            return (string.IsNullOrEmpty(path) || solutionDir == null) ? null :
-                Path.Combine(solutionDir, path);
+            var workDir = Directory.GetCurrentDirectory();
+            return (string.IsNullOrEmpty(path) || workDir == null) ? null :
+                Path.Combine(workDir, path);
         }
         #endregion
 


### PR DESCRIPTION
Default tasks using current directory.
"BuildEngine.ProjectFileOfTaskNode" point to project file path that written &lt;ILRepack&gt; task.

These projects show error "File not found", but not show "Directory not found".

&lt;MakeDir&gt; created: .\dest
&lt;ILRepack&gt; created: .\Common\dest\merged.dll

Common/Common.targets

``` xml
<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
  <Import Project="..\packages\ILRepack.MSBuild.Task.1.0.8\build\ILRepack.MSBuild.Task.targets" />
  <Target Name="Merge">
    <MakeDir Directories="$(DestDir)" />
    <ILRepack OutputFile="$(MergeOutput)" InputAssemblies="@(MergeFiles)" />
  </Target>
</Project>
```

Main.proj

``` xml
<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
  <Import Project="Common\Common.targets" />
  <PropertyGroup>
    <DestDir>dest\</DestDir>
    <MergeOutput>$(DestDir)merged.dll</MergeOutput>
  </PropertyGroup>
  <ItemGroup>
    <MergeFiles Include="src\*.dll" />
  </ItemGroup>
  <Target Name="Build" DependsOnTargets="Merge">
    <Error Text="Directory not found: $(DestDir)" Condition="!Exists('$(DestDir)')" />
    <Error Text="File not found: $(MergeOutput)" Condition="!Exists('$(MergeOutput)')" />
  </Target>
</Project>
```
