### PR TITLE
make dependencies private and include dlls in package

### DIFF
--- a/src/ILRepack.MSBuild.Task/ILRepack.MSBuild.Task.csproj
+++ b/src/ILRepack.MSBuild.Task/ILRepack.MSBuild.Task.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 
   <PropertyGroup>
     <PackageId>ILRepack.MSBuild.Task</PackageId>
@@ -41,9 +41,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" PrivateAssets="All" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);IncludeFilesInPackage</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+  <Target Name="IncludeFilesInPackage">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="$(OutputPath)\Microsoft.Build.Framework.dll" PackagePath="$(BuildOutputTargetFolder)\$(TargetFramework)" />
+      <TfmSpecificPackageFile Include="$(OutputPath)\Microsoft.Build.Utilities.Core.dll" PackagePath="$(BuildOutputTargetFolder)\$(TargetFramework)" />
+    </ItemGroup>
+  </Target>
 
   <ItemGroup>
     <ProjectReference Include="..\..\deps\ilrepack\deps\bamlparser\BamlParser.csproj" />


### PR DESCRIPTION
Your dependencies to Microsoft.Build.* are bleeding into the $(OutputPath) of the project that holds a reference to ILRepack.MSBuild.Task.

This pull request fixes that issue by moving said assemblies into the package and making the PackageReference private.

**Resulting changes the nuget structure to:**
```diff
ILRepack.MSBuild.Task.XXX.nupkg
     build\ ** (as always)
     buildMultiTargeting\ ** (as always)
     tools\ ** (as always)
     tasks\
         net46\
             ILRepack.MSBuild.Task.dll
+            Microsoft.Build.Framework.dll
+            Microsoft.Build.Utilities.Core.dll
         netcoreapp2.1\
             ILRepack.MSBuild.Task.dll
+            Microsoft.Build.Framework.dll
+            Microsoft.Build.Utilities.Core.dll
         netstandard2.0\
             ILRepack.MSBuild.Task.dll
+            Microsoft.Build.Framework.dll
+            Microsoft.Build.Utilities.Core.dll
```

**Resulting changes to the .nuspec**
```diff
<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
  <metadata>
    <!-- ... omitted ... -->
    <dependencies>
      <group targetFramework=".NETFramework4.6">
-        <dependency id="Microsoft.Build.Framework" version="15.9.20" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.Build.Utilities.Core" version="15.9.20" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETCoreApp2.1">
-        <dependency id="Microsoft.Build.Framework" version="15.9.20" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.Build.Utilities.Core" version="15.9.20" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard2.0">
-        <dependency id="Microsoft.Build.Framework" version="15.9.20" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.Build.Utilities.Core" version="15.9.20" exclude="Build,Analyzers" />
      </group>
    </dependencies>
  </metadata>
</package>
```